### PR TITLE
Dockerfile modified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM node:alpine as BUILD_IMAGE
 WORKDIR /app
 COPY package.json yarn.lock ./
 # install dependencies
-RUN yarn install --frozen-lockfile
+RUN yarn install
 COPY . .
 # build
 RUN yarn build
-# remove dev dependencies
-RUN npm prune --production
+
 FROM node:alpine
 WORKDIR /app
 # copy from build image


### PR DESCRIPTION
I have removed `npm install prune --production` command to use single package manager ( yarn ) and after doing so the build time and image size has decreased significantly. 

It resolves #36 